### PR TITLE
Bump fakedata-backend-base to 1.0.7

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Setup Python 3.9.4
+    - name: Setup Python 3.9.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9.4
+        python-version: 3.9.6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/dependabot_testing.yml
+++ b/.github/workflows/dependabot_testing.yml
@@ -31,10 +31,10 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Add Python 3.9.4
+    - name: Add Python 3.9.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9.4
+        python-version: 3.9.6
 
     - name: Add poetry 1.1.7
       uses: Gr1N/setup-poetry@v7

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.9.4
+        python-version: 3.9.6
     - uses: pre-commit/action@v2.0.3
 
   tests:
@@ -42,10 +42,10 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.CR_PAT }}
 
-    - name: Add Python 3.9.4
+    - name: Add Python 3.9.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9.4
+        python-version: 3.9.6
 
     - name: Add poetry 1.1.7
       uses: Gr1N/setup-poetry@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/randomicu/fakedata-backend-base:1.0.4 as builder-dev
+FROM ghcr.io/randomicu/fakedata-backend-base:1.0.6 as builder-dev
 
 RUN set -eux && \
     apt-get install --yes --no-install-recommends build-essential
@@ -8,7 +8,7 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-root --no-dev
 
 # Development image
-FROM ghcr.io/randomicu/fakedata-backend-base:1.0.4
+FROM ghcr.io/randomicu/fakedata-backend-base:1.0.6
 
 WORKDIR $PYSETUP_PATH
 COPY --from=builder-dev $POETRY_HOME $POETRY_HOME

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM ghcr.io/randomicu/fakedata-backend-base:1.0.4 as builder-dev
+FROM ghcr.io/randomicu/fakedata-backend-base:1.0.6 as builder-dev
 
 RUN set -eux && \
     apt-get install --yes --no-install-recommends build-essential
@@ -8,7 +8,7 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-root --no-dev
 
 # Production image
-FROM ghcr.io/randomicu/fakedata-backend-base:1.0.4
+FROM ghcr.io/randomicu/fakedata-backend-base:1.0.6
 
 WORKDIR $PYSETUP_PATH
 COPY --from=builder-dev $POETRY_HOME $POETRY_HOME


### PR DESCRIPTION
This also bumps Python to 3.9.6 as base image using it since [1.0.5](https://github.com/randomicu/fakedata-backend-base/releases/tag/v1.0.5)